### PR TITLE
Fix Issue 6 Unexpected mimeMessage content in withContentContains

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,16 @@
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
+        <dependency><!-- for Issue1Test -->
             <groupId>org.codemonkey.simplejavamail</groupId>
             <artifactId>simple-java-mail</artifactId>
             <version>2.5.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency><!-- for Issue6Test -->
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context-support</artifactId>
+            <version>4.2.4.RELEASE</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/net/kemitix/wiser/assertions/WiserAssertions.java
+++ b/src/main/java/net/kemitix/wiser/assertions/WiserAssertions.java
@@ -181,6 +181,9 @@ public final class WiserAssertions {
     private String getMimeMessageBody(final WiserMessage message)
             throws IOException, MessagingException {
         Object content = getMimeMessage(message).getContent();
+        if (content instanceof String) {
+            return (String) content;
+        }
         if (content instanceof MimeMessage) {
             return content.toString();
         }

--- a/src/test/java/net/kemitix/wiser/assertions/AbstractWiserTest.java
+++ b/src/test/java/net/kemitix/wiser/assertions/AbstractWiserTest.java
@@ -56,7 +56,7 @@ public abstract class AbstractWiserTest {
         Properties properties = new Properties();
         properties.setProperty("mail.transport.protocol", "smtp");
         properties.setProperty("mail.smtp.host", "localhost");
-        properties.setProperty("mail.smtp.port", "" + WiserAssertionsTest.PORT);
+        properties.setProperty("mail.smtp.port", "" + PORT);
         Session session = Session.getDefaultInstance(properties);
         return session;
     }

--- a/src/test/java/net/kemitix/wiser/assertions/AbstractWiserTest.java
+++ b/src/test/java/net/kemitix/wiser/assertions/AbstractWiserTest.java
@@ -57,7 +57,7 @@ public abstract class AbstractWiserTest {
         properties.setProperty("mail.transport.protocol", "smtp");
         properties.setProperty("mail.smtp.host", "localhost");
         properties.setProperty("mail.smtp.port", "" + PORT);
-        Session session = Session.getDefaultInstance(properties);
+        Session session = Session.getInstance(properties);
         return session;
     }
 

--- a/src/test/java/net/kemitix/wiser/assertions/Issue6Test.java
+++ b/src/test/java/net/kemitix/wiser/assertions/Issue6Test.java
@@ -30,7 +30,9 @@ public class Issue6Test extends AbstractWiserTest {
         //when
         sender.send(message);
         //then
-        getAssertions().withContentContains("Hi Carl");
+        getAssertions().from("bob@a.com").to("carl@b.com")
+                .withSubject("Subject")
+                .withContentContains("Hi Carl");
     }
 
 }

--- a/src/test/java/net/kemitix/wiser/assertions/Issue6Test.java
+++ b/src/test/java/net/kemitix/wiser/assertions/Issue6Test.java
@@ -1,0 +1,36 @@
+package net.kemitix.wiser.assertions;
+
+import org.junit.Test;
+
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+/**
+ * Regression test for issue #6.
+ *
+ * @see https://github.com/kemitix/wiser-assertions/issues/6
+ * @author pcampbell
+ */
+public class Issue6Test extends AbstractWiserTest {
+
+    /**
+     * Test {@link WiserAssertions#withContentContains(String)} where the
+     * message is a Spring Mail {@link SimpleMailMessage}.
+     */
+    @Test
+    public void shouldMatchContentContainsFromSimpleMailMessage() {
+        //given
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo("Carl <carl@b.com>");
+        message.setFrom("Bob <bob@a.com>");
+        message.setSubject("Subject");
+        message.setText("Hi Carl,\n\nA new message was just posted.");
+        final JavaMailSenderImpl sender = new JavaMailSenderImpl();
+        sender.setPort(PORT);
+        //when
+        sender.send(message);
+        //then
+        getAssertions().withContentContains("Hi Carl");
+    }
+
+}


### PR DESCRIPTION
Spring Mail's SimpleMailMessage doesn't wrap it's message body in a MimeMessage or MimeMultipart. Instead, it treats is as a simple String. This pull request adds support for this method of presenting the body.