### PR TITLE
Upgrade to test with simple-java-mail 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency><!-- for Issue1Test -->
             <groupId>org.codemonkey.simplejavamail</groupId>
             <artifactId>simple-java-mail</artifactId>
-            <version>2.5.1</version>
+            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency><!-- for Issue6Test -->

--- a/src/test/java/net/kemitix/wiser/assertions/Issue1Test.java
+++ b/src/test/java/net/kemitix/wiser/assertions/Issue1Test.java
@@ -1,7 +1,7 @@
 package net.kemitix.wiser.assertions;
 
-import org.codemonkey.simplejavamail.Email;
 import org.codemonkey.simplejavamail.Mailer;
+import org.codemonkey.simplejavamail.email.Email;
 import org.junit.Test;
 
 import javax.mail.Message;
@@ -9,8 +9,8 @@ import javax.mail.Message;
 /**
  * Regression test for issue #1.
  *
- * @see https://github.com/kemitix/wiser-assertions/issues/1
  * @author pcampbell
+ * @see https://github.com/kemitix/wiser-assertions/issues/1
  */
 public class Issue1Test extends AbstractWiserTest {
 


### PR DESCRIPTION
In simple-java-mail the Email class has been moved into the 'email' package, thus the Issue1Test had to be updated. This doesn't affect how wiser-assertions is used.