### PR TITLE
Bump kemitix depedencies and convert changelog to org-mode

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,6 +1,6 @@
 * CHANGELOG
 
-** next-release
+** [0.5.1] - unreleased
 
 *** Dependencies
 

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -18,7 +18,7 @@ The format is based on [[https://keepachangelog.com/en/1.0.0/][Keep a Changelog]
    - Bump kemitix-parent from 5.1.1 to 5.2.0
    - Bump spring-context-support from 5.0.8 to 5.1.3
    - Bump kemitix-checkstyle-ruleset from 4.1.1 to 5.3.2
-   - Bump kemitix-maven-tiles from 0.9.0 to 2.1.1
+   - Bump kemitix-maven-tiles from 0.9.0 to 2.1.2
 
 ** Removed
 

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,70 +1,80 @@
 * CHANGELOG
 
-** [0.5.1] - unreleased
+All notable changes to this project will be documented in this file.
 
-*** Dependencies
+The format is based on [[https://keepachangelog.com/en/1.0.0/][Keep a Changelog]], and this project adheres to
+[[https://semver.org/spec/v2.0.0.html][Semantic Versioning]].
 
-   * Bump mockito-core from 2.21.0 to 2.23.0
-   * Bump mon from 0.12.0 to 2.0.0
-   * Bump kemitix-parent from 5.1.1 to 5.2.0
-   * Bump spring-context-support from 5.0.8 to 5.1.2
-   * Bump kemitix-checkstyle-ruleset from 4.1.1 to 5.2.0
-   * Bump kemitix-maven-tiles from 0.9.0 to 2.0.0
+* 0.5.1
 
-*** Removed
+** Changed
 
-   * Remove travis config
+   - Suppress spotbugs warning about softening checked exceptions
 
-** 0.5.0
+** Dependencies
 
-  * Compatible with Java 10
-  * Bump kemitix-parent from 1.1.0 to 5.1.1
-  * Use kemitix-checkstyle-ruleset 4.1.1
-  * Don't throw generic exceptions
-  * Add mon 0.12.0 as dependency
-  * Bump tiles-maven-plugin from 2.11 to 2.12
-  * [testing] Use a free port for test mail server
-  * [testing] Bump mockito-core from 1.10.19 to 2.21.0
-  * [testing] Bump spring-context-support from 4.2.6.RELEASE to 5.0.8.RELEASE
-  * [testing] Bump simple-java-mail from 3.0.1 to 3.1.1
-  * [admin] Simpliify .gitignore
-  * [admin] Remove old netbeans config
-  * [admin] Switch to trunk based development
-  * [admin] Stop submitting coverage reports to coveralls
-  * [admin] Switch to Jenkins for CI/CD
+   - Bump mockito-core from 2.21.0 to 2.23.4
+   - Bump mon from 0.12.0 to 2.0.0
+   - Bump kemitix-parent from 5.1.1 to 5.2.0
+   - Bump spring-context-support from 5.0.8 to 5.1.3
+   - Bump kemitix-checkstyle-ruleset from 4.1.1 to 5.3.2
+   - Bump kemitix-maven-tiles from 0.9.0 to 2.1.1
 
-** 0.4.0
+** Removed
 
-  * Upgrade kemitix-parent to 1.1.0
-  * (pom) Specify dependency versions in properties
-  * Upgrade spring-context-support to 4.2.6 (tests)
-  * Upgrade simple-java-mail to 3.0.1 (tests)
+   - Remove travis config
+   - Remove CI dependency on sonarcloud
 
-** 0.3.2
+* 0.5.0
 
-  * Upgrade to test with spring-context-support 4.2.5
-  * Upgrade to test with simple-java-mail 3.0.0
-  * Upgrade kemitix-parent to 0.9.0
+ * Compatible with Java 10
+ * Bump kemitix-parent from 1.1.0 to 5.1.1
+ * Use kemitix-checkstyle-ruleset 4.1.1
+ * Don't throw generic exceptions
+ * Add mon 0.12.0 as dependency
+ * Bump tiles-maven-plugin from 2.11 to 2.12
+ * [testing] Use a free port for test mail server
+ * [testing] Bump mockito-core from 1.10.19 to 2.21.0
+ * [testing] Bump spring-context-support from 4.2.6.RELEASE to 5.0.8.RELEASE
+ * [testing] Bump simple-java-mail from 3.0.1 to 3.1.1
+ * [admin] Simpliify .gitignore
+ * [admin] Remove old netbeans config
+ * [admin] Switch to trunk based development
+ * [admin] Stop submitting coverage reports to coveralls
+ * [admin] Switch to Jenkins for CI/CD
 
-** 0.3.1
+* 0.4.0
 
-  * Add support for Spring Mail's SimpleMailMessage [fixes #6]
-  * Upgrade kemitix-parent to 0.7.1
+ * Upgrade kemitix-parent to 1.1.0
+ * (pom) Specify dependency versions in properties
+ * Upgrade spring-context-support to 4.2.6 (tests)
+ * Upgrade simple-java-mail to 3.0.1 (tests)
 
-** 0.3.0
+* 0.3.2
 
-  * Add support for nested multi-part emails [jonjo-manywho] [#1]
+ * Upgrade to test with spring-context-support 4.2.5
+ * Upgrade to test with simple-java-mail 3.0.0
+ * Upgrade kemitix-parent to 0.9.0
 
-** 0.2.0
+* 0.3.1
 
-  * 4d01349 Add tests with improved conversion of MIME Multipart messages to string
-  * d72ca46 Apply Checkstyle formatting (modified sun_checks) rules and add javadoc
+ * Add support for Spring Mail's SimpleMailMessage [fixes #6]
+ * Upgrade kemitix-parent to 0.7.1
 
-** 0.1.1
+* 0.3.0
 
-  * Upgrade javax.mail to 1.4.7
+ * Add support for nested multi-part emails [jonjo-manywho] [#1]
 
-** 0.1.0
+* 0.2.0
 
-  * Initial release
+ * 4d01349 Add tests with improved conversion of MIME Multipart messages to string
+ * d72ca46 Apply Checkstyle formatting (modified sun_checks) rules and add javadoc
+
+* 0.1.1
+
+ * Upgrade javax.mail to 1.4.7
+
+* 0.1.0
+
+ * Initial release
 

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,7 +9,7 @@
    * Bump kemitix-parent from 5.1.1 to 5.2.0
    * Bump spring-context-support from 5.0.8 to 5.1.2
    * Bump kemitix-checkstyle-ruleset from 4.1.1 to 5.2.0
-   * Bump kemitix-maven-tiles from 0.9.0 to 1.3.1
+   * Bump kemitix-maven-tiles from 0.9.0 to 2.0.0
 
 *** Removed
 

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -39,16 +39,6 @@ pipeline {
                 }
             }
         }
-        stage('SonarQube (published)') {
-            when { expression { isPublished(publicRepo) } }
-            steps {
-                withSonarQubeEnv('sonarqube') {
-                    withMaven(maven: 'maven', jdk: 'JDK 1.8') {
-                        sh "${mvn} org.sonarsource.scanner.maven:sonar-maven-plugin:3.4.0.905:sonar"
-                    }
-                }
-            }
-        }
         stage('Deploy (published release branch)') {
             when {
                 expression {

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <properties>
         <tiles-maven-plugin.version>2.12</tiles-maven-plugin.version>
         <kemitix-maven-tiles.version>1.3.1</kemitix-maven-tiles.version>
+        <kemitix-tiles.version>0.9.0</kemitix-tiles.version>
         <kemitix-checkstyle.version>5.2.0</kemitix-checkstyle.version>
         <digraph-dependency.basePackage>net.kemitix.wiser.assertions</digraph-dependency.basePackage>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <tiles-maven-plugin.version>2.12</tiles-maven-plugin.version>
-        <kemitix-maven-tiles.version>2.1.1</kemitix-maven-tiles.version>
+        <kemitix-maven-tiles.version>2.1.2</kemitix-maven-tiles.version>
         <kemitix-tiles.version>0.9.0</kemitix-tiles.version>
         <kemitix-checkstyle.version>5.3.2</kemitix-checkstyle.version>
         <digraph-dependency.basePackage>net.kemitix.wiser.assertions</digraph-dependency.basePackage>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <jacoco-class-instruction-covered-ratio>0</jacoco-class-instruction-covered-ratio>
         <jacoco-class-missed-count-maximum>1</jacoco-class-missed-count-maximum>
         <mon.version>2.0.0</mon.version>
+        <spotbugs.version>3.1.8</spotbugs.version>
     </properties>
 
     <dependencies>
@@ -92,6 +93,12 @@
             <artifactId>spring-context-support</artifactId>
             <version>${spring-framework.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <version>${spotbugs.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <tiles-maven-plugin.version>2.12</tiles-maven-plugin.version>
-        <kemitix-maven-tiles.version>1.3.1</kemitix-maven-tiles.version>
+        <kemitix-maven-tiles.version>2.0.0</kemitix-maven-tiles.version>
         <kemitix-tiles.version>0.9.0</kemitix-tiles.version>
         <kemitix-checkstyle.version>5.2.0</kemitix-checkstyle.version>
         <digraph-dependency.basePackage>net.kemitix.wiser.assertions</digraph-dependency.basePackage>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <tiles-maven-plugin.version>2.12</tiles-maven-plugin.version>
-        <kemitix-maven-tiles.version>2.0.0</kemitix-maven-tiles.version>
+        <kemitix-maven-tiles.version>2.1.1</kemitix-maven-tiles.version>
         <kemitix-tiles.version>0.9.0</kemitix-tiles.version>
         <kemitix-checkstyle.version>5.3.2</kemitix-checkstyle.version>
         <digraph-dependency.basePackage>net.kemitix.wiser.assertions</digraph-dependency.basePackage>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <tiles-maven-plugin.version>2.12</tiles-maven-plugin.version>
         <kemitix-maven-tiles.version>2.0.0</kemitix-maven-tiles.version>
         <kemitix-tiles.version>0.9.0</kemitix-tiles.version>
-        <kemitix-checkstyle.version>5.2.0</kemitix-checkstyle.version>
+        <kemitix-checkstyle.version>5.3.2</kemitix-checkstyle.version>
         <digraph-dependency.basePackage>net.kemitix.wiser.assertions</digraph-dependency.basePackage>
 
         <javax-mail.version>1.4.7</javax-mail.version>

--- a/src/main/java/net/kemitix/wiser/assertions/WiserAssertions.java
+++ b/src/main/java/net/kemitix/wiser/assertions/WiserAssertions.java
@@ -21,6 +21,7 @@
 
 package net.kemitix.wiser.assertions;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.kemitix.mon.maybe.Maybe;
 import net.kemitix.mon.result.Result;
 import org.subethamail.wiser.Wiser;
@@ -171,6 +172,7 @@ public final class WiserAssertions {
         return this;
     }
 
+    @SuppressFBWarnings("EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS")
     private String subject(final WiserMessage wiserMessage) {
         try {
             return wiserMessage.getMimeMessage().getSubject();
@@ -207,6 +209,7 @@ public final class WiserAssertions {
         return this;
     }
 
+    @SuppressFBWarnings("EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS")
     private String messageBody(final WiserMessage m) {
         try {
             return messageBody(m.getMimeMessage().getContent());


### PR DESCRIPTION
**Bump kemitix-checkstyle-ruleset from 4.1.1 to 5.2.0**

**Bump kemitix-maven-tiles from 0.9.0 to 2.0.0**

**[changelog] reformat in org-mode**

**[changelog] update for next-release**