### PR TITLE
Drop JDK 8 Support

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -3,12 +3,12 @@
     <servers>
         <server>
             <id>sonatype-nexus-snapshots</id>
-            <username>${env.NEXUS_USERNAME}</username>
+            <username>kemitix</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
         <server>
             <id>sonatype-nexus-staging</id>
-            <username>${env.NEXUS_USERNAME}</username>
+            <username>kemitix</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
     </servers>

--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11, 15 ]
+        java: [ 11, 16, 17-ea ]
     steps:
       - uses: actions/checkout@v2
       - name: setup-jdk-${{ matrix.java }}

--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         java: [ 8, 11, 15 ]
     steps:
-      - uses: kamiazya/setup-graphviz@v1
       - uses: actions/checkout@v2
       - name: setup-jdk-${{ matrix.java }}
         uses: actions/setup-java@v1
@@ -21,3 +20,5 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: build-jar
         run: mvn -B install
+      - name: verify javadoc
+        run: mvn -P release javadoc:javadoc

--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -15,8 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: setup-jdk-${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
+          distribution: adopt
           java-version: ${{ matrix.java }}
       - name: build-jar
         run: mvn -B install

--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 15 ]
+        java: [ 11, 15 ]
     steps:
       - uses: actions/checkout@v2
       - name: setup-jdk-${{ matrix.java }}

--- a/.github/workflows/deploy-sonatype.yml
+++ b/.github/workflows/deploy-sonatype.yml
@@ -33,7 +33,6 @@ jobs:
             -B \
             deploy
         env:
-          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
           GPG_KEYNAME: ${{ secrets.GPG_KEYNAME }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/deploy-sonatype.yml
+++ b/.github/workflows/deploy-sonatype.yml
@@ -36,3 +36,8 @@ jobs:
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
           GPG_KEYNAME: ${{ secrets.GPG_KEYNAME }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Publish Javadoc
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: target/apidocs # The folder the action should deploy.

--- a/.github/workflows/deploy-sonatype.yml
+++ b/.github/workflows/deploy-sonatype.yml
@@ -9,7 +9,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: kamiazya/setup-graphviz@v1
       - uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v1

--- a/.github/workflows/deploy-sonatype.yml
+++ b/.github/workflows/deploy-sonatype.yml
@@ -11,8 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
+          distribution: adopt
           java-version: 8
       - name: Build with Maven
         run: mvn -B install


### PR DESCRIPTION
Update to CI pipeline:

- Build for JDK 11 - dropping JDK 8
- Test build on JDK 16 and 17-ea
- Verify Javadoc is valid during PRs
- Publish Javadoc to https://kemitix.github.io/wiser-assertions/